### PR TITLE
Rename test file so that the JS tests are actually run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -90,16 +90,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   generate_coverage_data:
     continue-on-error: true
     env:
@@ -128,14 +128,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Echo Coverage Output Dir
@@ -155,7 +155,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint:
     container: golangci/golangci-lint:latest
     name: lint
@@ -175,7 +175,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -192,7 +192,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint_sdk:
     container: golangci/golangci-lint:latest
     name: lint-sdk
@@ -213,7 +213,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -230,7 +230,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -249,14 +249,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Build tfgen & provider binaries
@@ -300,11 +300,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish:
     name: publish
     needs: test
@@ -319,7 +319,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -356,11 +356,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -380,7 +380,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -440,11 +440,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   test:
     name: test
     needs: build_sdk
@@ -464,7 +464,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -511,7 +511,7 @@ jobs:
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
@@ -530,16 +530,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: main
 on:
   push:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -90,16 +90,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   generate_coverage_data:
     continue-on-error: true
     env:
@@ -128,14 +128,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Echo Coverage Output Dir
@@ -155,7 +155,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint:
     container: golangci/golangci-lint:latest
     name: lint
@@ -175,7 +175,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -192,7 +192,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint_sdk:
     container: golangci/golangci-lint:latest
     name: lint-sdk
@@ -213,7 +213,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -230,7 +230,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -249,14 +249,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Build tfgen & provider binaries
@@ -300,11 +300,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish:
     name: publish
     needs: test
@@ -319,7 +319,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -356,11 +356,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -380,7 +380,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -440,11 +440,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   test:
     name: test
     needs: build_sdk
@@ -464,7 +464,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -511,7 +511,7 @@ jobs:
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
@@ -530,16 +530,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: master
 on:
   push:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -90,16 +90,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -118,14 +118,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Build tfgen & provider binaries
@@ -169,11 +169,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   test:
     name: test
     needs: build_sdk
@@ -193,7 +193,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -240,7 +240,7 @@ jobs:
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
@@ -259,16 +259,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: cron
 on:
   schedule:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -90,16 +90,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   lint:
     container: golangci/golangci-lint:latest
     name: lint
@@ -119,7 +119,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -136,7 +136,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint_sdk:
     container: golangci/golangci-lint:latest
     name: lint-sdk
@@ -157,7 +157,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -174,7 +174,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -193,14 +193,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Build tfgen & provider binaries
@@ -244,11 +244,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish:
     name: publish
     needs: test
@@ -263,7 +263,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -300,11 +300,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -324,7 +324,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -384,11 +384,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   test:
     name: test
     needs: build_sdk
@@ -408,7 +408,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -455,7 +455,7 @@ jobs:
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
@@ -474,16 +474,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: prerelease
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -90,23 +90,23 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   create_docs_build:
     name: create_docs_build
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - env:
@@ -133,7 +133,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -150,7 +150,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint_sdk:
     container: golangci/golangci-lint:latest
     name: lint-sdk
@@ -171,7 +171,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -188,7 +188,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -207,14 +207,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Build tfgen & provider binaries
@@ -258,11 +258,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish:
     name: publish
     needs: test
@@ -277,7 +277,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -313,11 +313,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -337,7 +337,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -397,11 +397,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk
@@ -410,7 +410,7 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
@@ -435,7 +435,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -482,7 +482,7 @@ jobs:
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
@@ -501,16 +501,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: release
 on:
   push:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -95,16 +95,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification
@@ -144,7 +144,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -161,7 +161,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   lint_sdk:
     container: golangci/golangci-lint:latest
     if: github.event_name == 'repository_dispatch' ||
@@ -186,7 +186,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -203,7 +203,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.18.x
+        - 1.19.x
   prerequisites:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -226,14 +226,14 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: mikhailshilkov/schema-tools
     - name: Build tfgen & provider binaries
@@ -277,11 +277,23 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
+  sentinel:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: sentinel
+    needs:
+    - test
+    - lint
+    - lint_sdk
+    runs-on: ubuntu-latest
+    steps:
+    - name: Is workflow a success
+      run: echo yes
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -305,7 +317,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -352,7 +364,7 @@ jobs:
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
@@ -371,16 +383,16 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: run-acceptance-tests
 on:
   pull_request:

--- a/.github/workflows/update-bridge.yml
+++ b/.github/workflows/update-bridge.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -78,11 +78,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:

--- a/.github/workflows/update-upstream-provider.yml
+++ b/.github/workflows/update-upstream-provider.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         go-version: ${{matrix.goversion}}
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
@@ -128,11 +128,11 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.18.x
+        - 1.19.x
         nodeversion:
-        - 14.x
+        - 16.x
         pythonversion:
-        - "3.7"
+        - "3.9"
 name: Update upstream provider
 on:
   workflow_dispatch:

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+//go:build dotnet || all
 // +build dotnet all
 
 package examples

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+//go:build go || all
 // +build go all
 
 package examples

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+//go:build nodejs || all
 // +build nodejs all
 
 package examples

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+//go:build python || all
 // +build python all
 
 package examples

--- a/sdk/dotnet/go.mod
+++ b/sdk/dotnet/go.mod
@@ -1,0 +1,3 @@
+module fake_dotnet_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/go/wavefront/alert.go
+++ b/sdk/go/wavefront/alert.go
@@ -19,30 +19,33 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewAlert(ctx, "foobar", &wavefront.AlertArgs{
-// 			Condition:           pulumi.String("100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total ) > 80"),
-// 			DisplayExpression:   pulumi.String("100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total )"),
-// 			Minutes:             pulumi.Int(5),
-// 			ResolveAfterMinutes: pulumi.Int(5),
-// 			Severity:            pulumi.String("WARN"),
-// 			Tags: pulumi.StringArray{
-// 				pulumi.String("terraform"),
-// 				pulumi.String("test"),
-// 			},
-// 			Target: pulumi.String("test@example.com,target:alert-target-id"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewAlert(ctx, "foobar", &wavefront.AlertArgs{
+//				Condition:           pulumi.String("100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total ) > 80"),
+//				DisplayExpression:   pulumi.String("100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total )"),
+//				Minutes:             pulumi.Int(5),
+//				ResolveAfterMinutes: pulumi.Int(5),
+//				Severity:            pulumi.String("WARN"),
+//				Tags: pulumi.StringArray{
+//					pulumi.String("terraform"),
+//					pulumi.String("test"),
+//				},
+//				Target: pulumi.String("test@example.com,target:alert-target-id"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -50,7 +53,9 @@ import (
 // Alerts can be imported using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/alert:Alert alert_target 1479868728473
+//
+//	$ pulumi import wavefront:index/alert:Alert alert_target 1479868728473
+//
 // ```
 type Alert struct {
 	pulumi.CustomResourceState
@@ -349,7 +354,7 @@ func (i *Alert) ToAlertOutputWithContext(ctx context.Context) AlertOutput {
 // AlertArrayInput is an input type that accepts AlertArray and AlertArrayOutput values.
 // You can construct a concrete instance of `AlertArrayInput` via:
 //
-//          AlertArray{ AlertArgs{...} }
+//	AlertArray{ AlertArgs{...} }
 type AlertArrayInput interface {
 	pulumi.Input
 
@@ -374,7 +379,7 @@ func (i AlertArray) ToAlertArrayOutputWithContext(ctx context.Context) AlertArra
 // AlertMapInput is an input type that accepts AlertMap and AlertMapOutput values.
 // You can construct a concrete instance of `AlertMapInput` via:
 //
-//          AlertMap{ "key": AlertArgs{...} }
+//	AlertMap{ "key": AlertArgs{...} }
 type AlertMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/alertTarget.go
+++ b/sdk/go/wavefront/alertTarget.go
@@ -19,32 +19,35 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewAlertTarget(ctx, "testTarget", &wavefront.AlertTargetArgs{
-// 			ContentType: pulumi.String("application/json"),
-// 			CustomHeaders: pulumi.StringMap{
-// 				"Testing": pulumi.String("true"),
-// 			},
-// 			Description: pulumi.String("Test target"),
-// 			Method:      pulumi.String("WEBHOOK"),
-// 			Recipient:   pulumi.String("https://hooks.slack.com/services/test/me"),
-// 			Template:    pulumi.String("{}"),
-// 			Triggers: pulumi.StringArray{
-// 				pulumi.String("ALERT_OPENED"),
-// 				pulumi.String("ALERT_RESOLVED"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewAlertTarget(ctx, "testTarget", &wavefront.AlertTargetArgs{
+//				ContentType: pulumi.String("application/json"),
+//				CustomHeaders: pulumi.StringMap{
+//					"Testing": pulumi.String("true"),
+//				},
+//				Description: pulumi.String("Test target"),
+//				Method:      pulumi.String("WEBHOOK"),
+//				Recipient:   pulumi.String("https://hooks.slack.com/services/test/me"),
+//				Template:    pulumi.String("{}"),
+//				Triggers: pulumi.StringArray{
+//					pulumi.String("ALERT_OPENED"),
+//					pulumi.String("ALERT_RESOLVED"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ## Attributes Reference
 //
@@ -54,11 +57,11 @@ import (
 //
 // The `route` mapping supports the following:
 //
-// * `method` - (Required)  The notification method used for notification target. One of `WEBHOOK`, `EMAIL`, `PAGERDUTY`.
-// * `target` - (Required) The endpoint for the alert route. `EMAIL`: email address. `PAGERDUTY`: PagerDuty routing
-//   key. `WEBHOOK`: URL endpoint.
-// * `filter` - (Required) String that filters the route. Space delimited.  Currently only allows a single key value pair.
-//   (e.g. `env prod`)
+//   - `method` - (Required)  The notification method used for notification target. One of `WEBHOOK`, `EMAIL`, `PAGERDUTY`.
+//   - `target` - (Required) The endpoint for the alert route. `EMAIL`: email address. `PAGERDUTY`: PagerDuty routing
+//     key. `WEBHOOK`: URL endpoint.
+//   - `filter` - (Required) String that filters the route. Space delimited.  Currently only allows a single key value pair.
+//     (e.g. `env prod`)
 //
 // ### Example
 //
@@ -66,50 +69,53 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewAlertTarget(ctx, "testTarget", &wavefront.AlertTargetArgs{
-// 			ContentType: pulumi.String("application/json"),
-// 			CustomHeaders: pulumi.StringMap{
-// 				"Testing": pulumi.String("true"),
-// 			},
-// 			Description: pulumi.String("Test target"),
-// 			Method:      pulumi.String("WEBHOOK"),
-// 			Recipient:   pulumi.String("https://hooks.slack.com/services/test/me"),
-// 			Routes: AlertTargetRouteArray{
-// 				&AlertTargetRouteArgs{
-// 					Filter: pulumi.StringMap{
-// 						"key":   pulumi.String("env"),
-// 						"value": pulumi.String("prod"),
-// 					},
-// 					Method: pulumi.String("WEBHOOK"),
-// 					Target: pulumi.String("https://hooks.slack.com/services/test/me/prod"),
-// 				},
-// 				&AlertTargetRouteArgs{
-// 					Filter: pulumi.StringMap{
-// 						"key":   pulumi.String("env"),
-// 						"value": pulumi.String("dev"),
-// 					},
-// 					Method: pulumi.String("WEBHOOK"),
-// 					Target: pulumi.String("https://hooks.slack.com/services/test/me/dev"),
-// 				},
-// 			},
-// 			Template: pulumi.String("{}"),
-// 			Triggers: pulumi.StringArray{
-// 				pulumi.String("ALERT_OPENED"),
-// 				pulumi.String("ALERT_RESOLVED"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewAlertTarget(ctx, "testTarget", &wavefront.AlertTargetArgs{
+//				ContentType: pulumi.String("application/json"),
+//				CustomHeaders: pulumi.StringMap{
+//					"Testing": pulumi.String("true"),
+//				},
+//				Description: pulumi.String("Test target"),
+//				Method:      pulumi.String("WEBHOOK"),
+//				Recipient:   pulumi.String("https://hooks.slack.com/services/test/me"),
+//				Routes: AlertTargetRouteArray{
+//					&AlertTargetRouteArgs{
+//						Filter: pulumi.StringMap{
+//							"key":   pulumi.String("env"),
+//							"value": pulumi.String("prod"),
+//						},
+//						Method: pulumi.String("WEBHOOK"),
+//						Target: pulumi.String("https://hooks.slack.com/services/test/me/prod"),
+//					},
+//					&AlertTargetRouteArgs{
+//						Filter: pulumi.StringMap{
+//							"key":   pulumi.String("env"),
+//							"value": pulumi.String("dev"),
+//						},
+//						Method: pulumi.String("WEBHOOK"),
+//						Target: pulumi.String("https://hooks.slack.com/services/test/me/dev"),
+//					},
+//				},
+//				Template: pulumi.String("{}"),
+//				Triggers: pulumi.StringArray{
+//					pulumi.String("ALERT_OPENED"),
+//					pulumi.String("ALERT_RESOLVED"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -117,7 +123,9 @@ import (
 // Alert Targets can be imported using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/alertTarget:AlertTarget alert_target abcdEFGhijKLMNO
+//
+//	$ pulumi import wavefront:index/alertTarget:AlertTarget alert_target abcdEFGhijKLMNO
+//
 // ```
 type AlertTarget struct {
 	pulumi.CustomResourceState
@@ -335,7 +343,7 @@ func (i *AlertTarget) ToAlertTargetOutputWithContext(ctx context.Context) AlertT
 // AlertTargetArrayInput is an input type that accepts AlertTargetArray and AlertTargetArrayOutput values.
 // You can construct a concrete instance of `AlertTargetArrayInput` via:
 //
-//          AlertTargetArray{ AlertTargetArgs{...} }
+//	AlertTargetArray{ AlertTargetArgs{...} }
 type AlertTargetArrayInput interface {
 	pulumi.Input
 
@@ -360,7 +368,7 @@ func (i AlertTargetArray) ToAlertTargetArrayOutputWithContext(ctx context.Contex
 // AlertTargetMapInput is an input type that accepts AlertTargetMap and AlertTargetMapOutput values.
 // You can construct a concrete instance of `AlertTargetMapInput` via:
 //
-//          AlertTargetMap{ "key": AlertTargetArgs{...} }
+//	AlertTargetMap{ "key": AlertTargetArgs{...} }
 type AlertTargetMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationAppDynamics.go
+++ b/sdk/go/wavefront/cloudIntegrationAppDynamics.go
@@ -20,23 +20,26 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationAppDynamics(ctx, "appDynamics", &wavefront.CloudIntegrationAppDynamicsArgs{
-// 			ControllerName:    pulumi.String("exampleController"),
-// 			EncryptedPassword: pulumi.String("encryptedPassword"),
-// 			UserName:          pulumi.String("example"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationAppDynamics(ctx, "appDynamics", &wavefront.CloudIntegrationAppDynamicsArgs{
+//				ControllerName:    pulumi.String("exampleController"),
+//				EncryptedPassword: pulumi.String("encryptedPassword"),
+//				UserName:          pulumi.String("example"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -44,7 +47,9 @@ import (
 // AppDynamic Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationAppDynamics:CloudIntegrationAppDynamics app_dynamics a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationAppDynamics:CloudIntegrationAppDynamics app_dynamics a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationAppDynamics struct {
 	pulumi.CustomResourceState
@@ -314,7 +319,7 @@ func (i *CloudIntegrationAppDynamics) ToCloudIntegrationAppDynamicsOutputWithCon
 // CloudIntegrationAppDynamicsArrayInput is an input type that accepts CloudIntegrationAppDynamicsArray and CloudIntegrationAppDynamicsArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationAppDynamicsArrayInput` via:
 //
-//          CloudIntegrationAppDynamicsArray{ CloudIntegrationAppDynamicsArgs{...} }
+//	CloudIntegrationAppDynamicsArray{ CloudIntegrationAppDynamicsArgs{...} }
 type CloudIntegrationAppDynamicsArrayInput interface {
 	pulumi.Input
 
@@ -339,7 +344,7 @@ func (i CloudIntegrationAppDynamicsArray) ToCloudIntegrationAppDynamicsArrayOutp
 // CloudIntegrationAppDynamicsMapInput is an input type that accepts CloudIntegrationAppDynamicsMap and CloudIntegrationAppDynamicsMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationAppDynamicsMapInput` via:
 //
-//          CloudIntegrationAppDynamicsMap{ "key": CloudIntegrationAppDynamicsArgs{...} }
+//	CloudIntegrationAppDynamicsMap{ "key": CloudIntegrationAppDynamicsArgs{...} }
 type CloudIntegrationAppDynamicsMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationAwsExternalId.go
+++ b/sdk/go/wavefront/cloudIntegrationAwsExternalId.go
@@ -18,19 +18,22 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "externalId", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "externalId", nil)
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -38,7 +41,9 @@ import (
 // External IDs can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationAwsExternalId:CloudIntegrationAwsExternalId external_id uGJdkH3k
+//
+//	$ pulumi import wavefront:index/cloudIntegrationAwsExternalId:CloudIntegrationAwsExternalId external_id uGJdkH3k
+//
 // ```
 type CloudIntegrationAwsExternalId struct {
 	pulumi.CustomResourceState
@@ -115,7 +120,7 @@ func (i *CloudIntegrationAwsExternalId) ToCloudIntegrationAwsExternalIdOutputWit
 // CloudIntegrationAwsExternalIdArrayInput is an input type that accepts CloudIntegrationAwsExternalIdArray and CloudIntegrationAwsExternalIdArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationAwsExternalIdArrayInput` via:
 //
-//          CloudIntegrationAwsExternalIdArray{ CloudIntegrationAwsExternalIdArgs{...} }
+//	CloudIntegrationAwsExternalIdArray{ CloudIntegrationAwsExternalIdArgs{...} }
 type CloudIntegrationAwsExternalIdArrayInput interface {
 	pulumi.Input
 
@@ -140,7 +145,7 @@ func (i CloudIntegrationAwsExternalIdArray) ToCloudIntegrationAwsExternalIdArray
 // CloudIntegrationAwsExternalIdMapInput is an input type that accepts CloudIntegrationAwsExternalIdMap and CloudIntegrationAwsExternalIdMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationAwsExternalIdMapInput` via:
 //
-//          CloudIntegrationAwsExternalIdMap{ "key": CloudIntegrationAwsExternalIdArgs{...} }
+//	CloudIntegrationAwsExternalIdMap{ "key": CloudIntegrationAwsExternalIdArgs{...} }
 type CloudIntegrationAwsExternalIdMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationAzure.go
+++ b/sdk/go/wavefront/cloudIntegrationAzure.go
@@ -20,23 +20,26 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationAzureActivityLog(ctx, "azureActivityLog", &wavefront.CloudIntegrationAzureActivityLogArgs{
-// 			ClientId:     pulumi.String("client-id2"),
-// 			ClientSecret: pulumi.String("client-secret2"),
-// 			Tenant:       pulumi.String("my-tenant2"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationAzureActivityLog(ctx, "azureActivityLog", &wavefront.CloudIntegrationAzureActivityLogArgs{
+//				ClientId:     pulumi.String("client-id2"),
+//				ClientSecret: pulumi.String("client-secret2"),
+//				Tenant:       pulumi.String("my-tenant2"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -44,7 +47,9 @@ import (
 // Azure Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationAzure:CloudIntegrationAzure azure a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationAzure:CloudIntegrationAzure azure a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationAzure struct {
 	pulumi.CustomResourceState
@@ -244,7 +249,7 @@ func (i *CloudIntegrationAzure) ToCloudIntegrationAzureOutputWithContext(ctx con
 // CloudIntegrationAzureArrayInput is an input type that accepts CloudIntegrationAzureArray and CloudIntegrationAzureArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationAzureArrayInput` via:
 //
-//          CloudIntegrationAzureArray{ CloudIntegrationAzureArgs{...} }
+//	CloudIntegrationAzureArray{ CloudIntegrationAzureArgs{...} }
 type CloudIntegrationAzureArrayInput interface {
 	pulumi.Input
 
@@ -269,7 +274,7 @@ func (i CloudIntegrationAzureArray) ToCloudIntegrationAzureArrayOutputWithContex
 // CloudIntegrationAzureMapInput is an input type that accepts CloudIntegrationAzureMap and CloudIntegrationAzureMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationAzureMapInput` via:
 //
-//          CloudIntegrationAzureMap{ "key": CloudIntegrationAzureArgs{...} }
+//	CloudIntegrationAzureMap{ "key": CloudIntegrationAzureArgs{...} }
 type CloudIntegrationAzureMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationAzureActivityLog.go
+++ b/sdk/go/wavefront/cloudIntegrationAzureActivityLog.go
@@ -20,26 +20,29 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationAzureActivityLog(ctx, "azureActivityLog", &wavefront.CloudIntegrationAzureActivityLogArgs{
-// 			CategoryFilters: pulumi.StringArray{
-// 				pulumi.String("ADMINISTRATIVE"),
-// 			},
-// 			ClientId:     pulumi.String("client-id2"),
-// 			ClientSecret: pulumi.String("client-secret2"),
-// 			Tenant:       pulumi.String("my-tenant2"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationAzureActivityLog(ctx, "azureActivityLog", &wavefront.CloudIntegrationAzureActivityLogArgs{
+//				CategoryFilters: pulumi.StringArray{
+//					pulumi.String("ADMINISTRATIVE"),
+//				},
+//				ClientId:     pulumi.String("client-id2"),
+//				ClientSecret: pulumi.String("client-secret2"),
+//				Tenant:       pulumi.String("my-tenant2"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -47,7 +50,9 @@ import (
 // Azure Activity Log Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationAzureActivityLog:CloudIntegrationAzureActivityLog azure_al a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationAzureActivityLog:CloudIntegrationAzureActivityLog azure_al a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationAzureActivityLog struct {
 	pulumi.CustomResourceState
@@ -227,7 +232,7 @@ func (i *CloudIntegrationAzureActivityLog) ToCloudIntegrationAzureActivityLogOut
 // CloudIntegrationAzureActivityLogArrayInput is an input type that accepts CloudIntegrationAzureActivityLogArray and CloudIntegrationAzureActivityLogArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationAzureActivityLogArrayInput` via:
 //
-//          CloudIntegrationAzureActivityLogArray{ CloudIntegrationAzureActivityLogArgs{...} }
+//	CloudIntegrationAzureActivityLogArray{ CloudIntegrationAzureActivityLogArgs{...} }
 type CloudIntegrationAzureActivityLogArrayInput interface {
 	pulumi.Input
 
@@ -252,7 +257,7 @@ func (i CloudIntegrationAzureActivityLogArray) ToCloudIntegrationAzureActivityLo
 // CloudIntegrationAzureActivityLogMapInput is an input type that accepts CloudIntegrationAzureActivityLogMap and CloudIntegrationAzureActivityLogMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationAzureActivityLogMapInput` via:
 //
-//          CloudIntegrationAzureActivityLogMap{ "key": CloudIntegrationAzureActivityLogArgs{...} }
+//	CloudIntegrationAzureActivityLogMap{ "key": CloudIntegrationAzureActivityLogArgs{...} }
 type CloudIntegrationAzureActivityLogMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationCloudTrail.go
+++ b/sdk/go/wavefront/cloudIntegrationCloudTrail.go
@@ -20,28 +20,31 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		extId, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "extId", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = wavefront.NewCloudIntegrationCloudTrail(ctx, "cloudtrail", &wavefront.CloudIntegrationCloudTrailArgs{
-// 			RoleArn:    pulumi.String("arn:aws::1234567:role/example-arn"),
-// 			ExternalId: extId.ID(),
-// 			Region:     pulumi.String("us-west-2"),
-// 			BucketName: pulumi.String("example-s3-bucket"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			extId, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "extId", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = wavefront.NewCloudIntegrationCloudTrail(ctx, "cloudtrail", &wavefront.CloudIntegrationCloudTrailArgs{
+//				RoleArn:    pulumi.String("arn:aws::1234567:role/example-arn"),
+//				ExternalId: extId.ID(),
+//				Region:     pulumi.String("us-west-2"),
+//				BucketName: pulumi.String("example-s3-bucket"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -49,7 +52,9 @@ import (
 // CloudTrail Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationCloudTrail:CloudIntegrationCloudTrail cloudtrail a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationCloudTrail:CloudIntegrationCloudTrail cloudtrail a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationCloudTrail struct {
 	pulumi.CustomResourceState
@@ -252,7 +257,7 @@ func (i *CloudIntegrationCloudTrail) ToCloudIntegrationCloudTrailOutputWithConte
 // CloudIntegrationCloudTrailArrayInput is an input type that accepts CloudIntegrationCloudTrailArray and CloudIntegrationCloudTrailArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationCloudTrailArrayInput` via:
 //
-//          CloudIntegrationCloudTrailArray{ CloudIntegrationCloudTrailArgs{...} }
+//	CloudIntegrationCloudTrailArray{ CloudIntegrationCloudTrailArgs{...} }
 type CloudIntegrationCloudTrailArrayInput interface {
 	pulumi.Input
 
@@ -277,7 +282,7 @@ func (i CloudIntegrationCloudTrailArray) ToCloudIntegrationCloudTrailArrayOutput
 // CloudIntegrationCloudTrailMapInput is an input type that accepts CloudIntegrationCloudTrailMap and CloudIntegrationCloudTrailMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationCloudTrailMapInput` via:
 //
-//          CloudIntegrationCloudTrailMap{ "key": CloudIntegrationCloudTrailArgs{...} }
+//	CloudIntegrationCloudTrailMap{ "key": CloudIntegrationCloudTrailArgs{...} }
 type CloudIntegrationCloudTrailMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationCloudWatch.go
+++ b/sdk/go/wavefront/cloudIntegrationCloudWatch.go
@@ -20,27 +20,30 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		extId, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "extId", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = wavefront.NewCloudIntegrationCloudWatch(ctx, "cloudwatch", &wavefront.CloudIntegrationCloudWatchArgs{
-// 			ForceSave:  pulumi.Bool(true),
-// 			RoleArn:    pulumi.String("arn:aws::1234567:role/example-arn"),
-// 			ExternalId: extId.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			extId, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "extId", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = wavefront.NewCloudIntegrationCloudWatch(ctx, "cloudwatch", &wavefront.CloudIntegrationCloudWatchArgs{
+//				ForceSave:  pulumi.Bool(true),
+//				RoleArn:    pulumi.String("arn:aws::1234567:role/example-arn"),
+//				ExternalId: extId.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -48,7 +51,9 @@ import (
 // CloudWatch Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationCloudWatch:CloudIntegrationCloudWatch cloudwatch a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationCloudWatch:CloudIntegrationCloudWatch cloudwatch a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationCloudWatch struct {
 	pulumi.CustomResourceState
@@ -280,7 +285,7 @@ func (i *CloudIntegrationCloudWatch) ToCloudIntegrationCloudWatchOutputWithConte
 // CloudIntegrationCloudWatchArrayInput is an input type that accepts CloudIntegrationCloudWatchArray and CloudIntegrationCloudWatchArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationCloudWatchArrayInput` via:
 //
-//          CloudIntegrationCloudWatchArray{ CloudIntegrationCloudWatchArgs{...} }
+//	CloudIntegrationCloudWatchArray{ CloudIntegrationCloudWatchArgs{...} }
 type CloudIntegrationCloudWatchArrayInput interface {
 	pulumi.Input
 
@@ -305,7 +310,7 @@ func (i CloudIntegrationCloudWatchArray) ToCloudIntegrationCloudWatchArrayOutput
 // CloudIntegrationCloudWatchMapInput is an input type that accepts CloudIntegrationCloudWatchMap and CloudIntegrationCloudWatchMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationCloudWatchMapInput` via:
 //
-//          CloudIntegrationCloudWatchMap{ "key": CloudIntegrationCloudWatchArgs{...} }
+//	CloudIntegrationCloudWatchMap{ "key": CloudIntegrationCloudWatchArgs{...} }
 type CloudIntegrationCloudWatchMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationEc2.go
+++ b/sdk/go/wavefront/cloudIntegrationEc2.go
@@ -20,26 +20,29 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		extId, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "extId", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = wavefront.NewCloudIntegrationEc2(ctx, "ec2", &wavefront.CloudIntegrationEc2Args{
-// 			RoleArn:    pulumi.String("arn:aws::1234567:role/example-arn"),
-// 			ExternalId: extId.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			extId, err := wavefront.NewCloudIntegrationAwsExternalId(ctx, "extId", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = wavefront.NewCloudIntegrationEc2(ctx, "ec2", &wavefront.CloudIntegrationEc2Args{
+//				RoleArn:    pulumi.String("arn:aws::1234567:role/example-arn"),
+//				ExternalId: extId.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -47,7 +50,9 @@ import (
 // EC2 Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationEc2:CloudIntegrationEc2 ec2 a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationEc2:CloudIntegrationEc2 ec2 a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationEc2 struct {
 	pulumi.CustomResourceState
@@ -224,7 +229,7 @@ func (i *CloudIntegrationEc2) ToCloudIntegrationEc2OutputWithContext(ctx context
 // CloudIntegrationEc2ArrayInput is an input type that accepts CloudIntegrationEc2Array and CloudIntegrationEc2ArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationEc2ArrayInput` via:
 //
-//          CloudIntegrationEc2Array{ CloudIntegrationEc2Args{...} }
+//	CloudIntegrationEc2Array{ CloudIntegrationEc2Args{...} }
 type CloudIntegrationEc2ArrayInput interface {
 	pulumi.Input
 
@@ -249,7 +254,7 @@ func (i CloudIntegrationEc2Array) ToCloudIntegrationEc2ArrayOutputWithContext(ct
 // CloudIntegrationEc2MapInput is an input type that accepts CloudIntegrationEc2Map and CloudIntegrationEc2MapOutput values.
 // You can construct a concrete instance of `CloudIntegrationEc2MapInput` via:
 //
-//          CloudIntegrationEc2Map{ "key": CloudIntegrationEc2Args{...} }
+//	CloudIntegrationEc2Map{ "key": CloudIntegrationEc2Args{...} }
 type CloudIntegrationEc2MapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationGcp.go
+++ b/sdk/go/wavefront/cloudIntegrationGcp.go
@@ -20,24 +20,27 @@ import (
 // package main
 //
 // import (
-// 	"fmt"
 //
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//	"fmt"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationGcp(ctx, "gcp", &wavefront.CloudIntegrationGcpArgs{
-// 			JsonKey:   pulumi.String(fmt.Sprintf("%v%v", "{...your gcp key ...}\n", "\n")),
-// 			ProjectId: pulumi.String("example-gcp-project"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationGcp(ctx, "gcp", &wavefront.CloudIntegrationGcpArgs{
+//				JsonKey:   pulumi.String(fmt.Sprintf("%v%v", "{...your gcp key ...}\n", "\n")),
+//				ProjectId: pulumi.String("example-gcp-project"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -45,7 +48,9 @@ import (
 // GCP Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationGcp:CloudIntegrationGcp gcp a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationGcp:CloudIntegrationGcp gcp a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationGcp struct {
 	pulumi.CustomResourceState
@@ -247,7 +252,7 @@ func (i *CloudIntegrationGcp) ToCloudIntegrationGcpOutputWithContext(ctx context
 // CloudIntegrationGcpArrayInput is an input type that accepts CloudIntegrationGcpArray and CloudIntegrationGcpArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationGcpArrayInput` via:
 //
-//          CloudIntegrationGcpArray{ CloudIntegrationGcpArgs{...} }
+//	CloudIntegrationGcpArray{ CloudIntegrationGcpArgs{...} }
 type CloudIntegrationGcpArrayInput interface {
 	pulumi.Input
 
@@ -272,7 +277,7 @@ func (i CloudIntegrationGcpArray) ToCloudIntegrationGcpArrayOutputWithContext(ct
 // CloudIntegrationGcpMapInput is an input type that accepts CloudIntegrationGcpMap and CloudIntegrationGcpMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationGcpMapInput` via:
 //
-//          CloudIntegrationGcpMap{ "key": CloudIntegrationGcpArgs{...} }
+//	CloudIntegrationGcpMap{ "key": CloudIntegrationGcpArgs{...} }
 type CloudIntegrationGcpMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationGcpBilling.go
+++ b/sdk/go/wavefront/cloudIntegrationGcpBilling.go
@@ -20,25 +20,28 @@ import (
 // package main
 //
 // import (
-// 	"fmt"
 //
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//	"fmt"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationGcpBilling(ctx, "gcpBilling", &wavefront.CloudIntegrationGcpBillingArgs{
-// 			ApiKey:    pulumi.String("example-api-key"),
-// 			JsonKey:   pulumi.String(fmt.Sprintf("%v%v", "{...your gcp key ...}\n", "\n")),
-// 			ProjectId: pulumi.String("example-gcp-project"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationGcpBilling(ctx, "gcpBilling", &wavefront.CloudIntegrationGcpBillingArgs{
+//				ApiKey:    pulumi.String("example-api-key"),
+//				JsonKey:   pulumi.String(fmt.Sprintf("%v%v", "{...your gcp key ...}\n", "\n")),
+//				ProjectId: pulumi.String("example-gcp-project"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -46,7 +49,9 @@ import (
 // GCP Billing Cloud Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationGcpBilling:CloudIntegrationGcpBilling gcp_billing a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationGcpBilling:CloudIntegrationGcpBilling gcp_billing a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationGcpBilling struct {
 	pulumi.CustomResourceState
@@ -221,7 +226,7 @@ func (i *CloudIntegrationGcpBilling) ToCloudIntegrationGcpBillingOutputWithConte
 // CloudIntegrationGcpBillingArrayInput is an input type that accepts CloudIntegrationGcpBillingArray and CloudIntegrationGcpBillingArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationGcpBillingArrayInput` via:
 //
-//          CloudIntegrationGcpBillingArray{ CloudIntegrationGcpBillingArgs{...} }
+//	CloudIntegrationGcpBillingArray{ CloudIntegrationGcpBillingArgs{...} }
 type CloudIntegrationGcpBillingArrayInput interface {
 	pulumi.Input
 
@@ -246,7 +251,7 @@ func (i CloudIntegrationGcpBillingArray) ToCloudIntegrationGcpBillingArrayOutput
 // CloudIntegrationGcpBillingMapInput is an input type that accepts CloudIntegrationGcpBillingMap and CloudIntegrationGcpBillingMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationGcpBillingMapInput` via:
 //
-//          CloudIntegrationGcpBillingMap{ "key": CloudIntegrationGcpBillingArgs{...} }
+//	CloudIntegrationGcpBillingMap{ "key": CloudIntegrationGcpBillingArgs{...} }
 type CloudIntegrationGcpBillingMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationNewRelic.go
+++ b/sdk/go/wavefront/cloudIntegrationNewRelic.go
@@ -20,21 +20,24 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationNewRelic(ctx, "newrelic", &wavefront.CloudIntegrationNewRelicArgs{
-// 			ApiKey: pulumi.String("example-api-key"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationNewRelic(ctx, "newrelic", &wavefront.CloudIntegrationNewRelicArgs{
+//				ApiKey: pulumi.String("example-api-key"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -42,7 +45,9 @@ import (
 // NewRelic Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationNewRelic:CloudIntegrationNewRelic newrelic a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationNewRelic:CloudIntegrationNewRelic newrelic a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationNewRelic struct {
 	pulumi.CustomResourceState
@@ -216,7 +221,7 @@ func (i *CloudIntegrationNewRelic) ToCloudIntegrationNewRelicOutputWithContext(c
 // CloudIntegrationNewRelicArrayInput is an input type that accepts CloudIntegrationNewRelicArray and CloudIntegrationNewRelicArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationNewRelicArrayInput` via:
 //
-//          CloudIntegrationNewRelicArray{ CloudIntegrationNewRelicArgs{...} }
+//	CloudIntegrationNewRelicArray{ CloudIntegrationNewRelicArgs{...} }
 type CloudIntegrationNewRelicArrayInput interface {
 	pulumi.Input
 
@@ -241,7 +246,7 @@ func (i CloudIntegrationNewRelicArray) ToCloudIntegrationNewRelicArrayOutputWith
 // CloudIntegrationNewRelicMapInput is an input type that accepts CloudIntegrationNewRelicMap and CloudIntegrationNewRelicMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationNewRelicMapInput` via:
 //
-//          CloudIntegrationNewRelicMap{ "key": CloudIntegrationNewRelicArgs{...} }
+//	CloudIntegrationNewRelicMap{ "key": CloudIntegrationNewRelicArgs{...} }
 type CloudIntegrationNewRelicMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/cloudIntegrationTesla.go
+++ b/sdk/go/wavefront/cloudIntegrationTesla.go
@@ -20,22 +20,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewCloudIntegrationTesla(ctx, "tesla", &wavefront.CloudIntegrationTeslaArgs{
-// 			Email:    pulumi.String("email@example.com"),
-// 			Password: pulumi.String("password"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewCloudIntegrationTesla(ctx, "tesla", &wavefront.CloudIntegrationTeslaArgs{
+//				Email:    pulumi.String("email@example.com"),
+//				Password: pulumi.String("password"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -43,7 +46,9 @@ import (
 // Tesla Integrations can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/cloudIntegrationTesla:CloudIntegrationTesla tesla a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/cloudIntegrationTesla:CloudIntegrationTesla tesla a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type CloudIntegrationTesla struct {
 	pulumi.CustomResourceState
@@ -200,7 +205,7 @@ func (i *CloudIntegrationTesla) ToCloudIntegrationTeslaOutputWithContext(ctx con
 // CloudIntegrationTeslaArrayInput is an input type that accepts CloudIntegrationTeslaArray and CloudIntegrationTeslaArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationTeslaArrayInput` via:
 //
-//          CloudIntegrationTeslaArray{ CloudIntegrationTeslaArgs{...} }
+//	CloudIntegrationTeslaArray{ CloudIntegrationTeslaArgs{...} }
 type CloudIntegrationTeslaArrayInput interface {
 	pulumi.Input
 
@@ -225,7 +230,7 @@ func (i CloudIntegrationTeslaArray) ToCloudIntegrationTeslaArrayOutputWithContex
 // CloudIntegrationTeslaMapInput is an input type that accepts CloudIntegrationTeslaMap and CloudIntegrationTeslaMapOutput values.
 // You can construct a concrete instance of `CloudIntegrationTeslaMapInput` via:
 //
-//          CloudIntegrationTeslaMap{ "key": CloudIntegrationTeslaArgs{...} }
+//	CloudIntegrationTeslaMap{ "key": CloudIntegrationTeslaArgs{...} }
 type CloudIntegrationTeslaMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/dashboard.go
+++ b/sdk/go/wavefront/dashboard.go
@@ -18,7 +18,9 @@ import (
 // Dashboards can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/dashboard:Dashboard dashboard tftestimport
+//
+//	$ pulumi import wavefront:index/dashboard:Dashboard dashboard tftestimport
+//
 // ```
 type Dashboard struct {
 	pulumi.CustomResourceState
@@ -233,7 +235,7 @@ func (i *Dashboard) ToDashboardOutputWithContext(ctx context.Context) DashboardO
 // DashboardArrayInput is an input type that accepts DashboardArray and DashboardArrayOutput values.
 // You can construct a concrete instance of `DashboardArrayInput` via:
 //
-//          DashboardArray{ DashboardArgs{...} }
+//	DashboardArray{ DashboardArgs{...} }
 type DashboardArrayInput interface {
 	pulumi.Input
 
@@ -258,7 +260,7 @@ func (i DashboardArray) ToDashboardArrayOutputWithContext(ctx context.Context) D
 // DashboardMapInput is an input type that accepts DashboardMap and DashboardMapOutput values.
 // You can construct a concrete instance of `DashboardMapInput` via:
 //
-//          DashboardMap{ "key": DashboardArgs{...} }
+//	DashboardMap{ "key": DashboardArgs{...} }
 type DashboardMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/dashboardJson.go
+++ b/sdk/go/wavefront/dashboardJson.go
@@ -19,23 +19,26 @@ import (
 // package main
 //
 // import (
-// 	"fmt"
 //
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//	"fmt"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewDashboardJson(ctx, "testDashboardJson", &wavefront.DashboardJsonArgs{
-// 			DashboardJson: pulumi.String(fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v", "{\n", "  \"name\": \"Terraform Test Dashboard Json\",\n", "  \"description\": \"a\",\n", "  \"eventFilterType\": \"BYCHART\",\n", "  \"eventQuery\": \"\",\n", "  \"defaultTimeWindow\": \"\",\n", "  \"url\": \"tftestimport\",\n", "  \"displayDescription\": false,\n", "  \"displaySectionTableOfContents\": true,\n", "  \"displayQueryParameters\": false,\n", "  \"sections\": [\n", "    {\n", "      \"name\": \"section 1\",\n", "      \"rows\": [\n", "        {\n", "          \"charts\": [\n", "            {\n", "              \"name\": \"chart 1\",\n", "              \"sources\": [\n", "                {\n", "                  \"name\": \"source 1\",\n", "                  \"query\": \"ts()\",\n", "                  \"scatterPlotSource\": \"Y\",\n", "                  \"querybuilderEnabled\": false,\n", "                  \"sourceDescription\": \"\"\n", "                }\n", "              ],\n", "              \"units\": \"someunit\",\n", "              \"base\": 0,\n", "              \"noDefaultEvents\": false,\n", "              \"interpolatePoints\": false,\n", "              \"includeObsoleteMetrics\": false,\n", "              \"description\": \"This is chart 1, showing something\",\n", "              \"chartSettings\": {\n", "                \"type\": \"markdown-widget\",\n", "                \"max\": 100,\n", "                \"expectedDataSpacing\": 120,\n", "                \"windowing\": \"full\",\n", "                \"windowSize\": 10,\n", "                \"autoColumnTags\": false,\n", "                \"columnTags\": \"deprecated\",\n", "                \"tagMode\": \"all\",\n", "                \"numTags\": 2,\n", "                \"customTags\": [\n", "                  \"tag1\",\n", "                  \"tag2\"\n", "                ],\n", "                \"groupBySource\": true,\n", "                \"y1Max\": 100,\n", "                \"y1Units\": \"units\",\n", "                \"y0ScaleSIBy1024\": true,\n", "                \"y1ScaleSIBy1024\": true,\n", "                \"y0UnitAutoscaling\": true,\n", "                \"y1UnitAutoscaling\": true,\n", "                \"fixedLegendEnabled\": true,\n", "                \"fixedLegendUseRawStats\": true,\n", "                \"fixedLegendPosition\": \"RIGHT\",\n", "                \"fixedLegendDisplayStats\": [\n", "                  \"stat1\",\n", "                  \"stat2\"\n", "                ],\n", "                \"fixedLegendFilterSort\": \"TOP\",\n", "                \"fixedLegendFilterLimit\": 1,\n", "                \"fixedLegendFilterField\": \"CURRENT\",\n", "                \"plainMarkdownContent\": \"markdown content\"\n", "              },\n", "              \"summarization\": \"MEAN\"\n", "            }\n", "          ],\n", "          \"heightFactor\": 50\n", "        }\n", "      ]\n", "    }\n", "  ],\n", "  \"parameterDetails\": {\n", "    \"param\": {\n", "      \"hideFromView\": false,\n", "      \"description\": null,\n", "      \"allowAll\": null,\n", "      \"tagKey\": null,\n", "      \"queryValue\": null,\n", "      \"dynamicFieldType\": null,\n", "      \"reverseDynSort\": null,\n", "      \"parameterType\": \"SIMPLE\",\n", "      \"label\": \"test\",\n", "      \"defaultValue\": \"Label\",\n", "      \"valuesToReadableStrings\": {\n", "        \"Label\": \"test\"\n", "      },\n", "      \"selectedLabel\": \"Label\",\n", "      \"value\": \"test\"\n", "    }\n", "  },\n", "  \"tags\" :{\n", "    \"customerTags\":  [\"terraform\"]\n", "  }\n", "}\n", "\n")),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewDashboardJson(ctx, "testDashboardJson", &wavefront.DashboardJsonArgs{
+//				DashboardJson: pulumi.String(fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v", "{\n", "  \"name\": \"Terraform Test Dashboard Json\",\n", "  \"description\": \"a\",\n", "  \"eventFilterType\": \"BYCHART\",\n", "  \"eventQuery\": \"\",\n", "  \"defaultTimeWindow\": \"\",\n", "  \"url\": \"tftestimport\",\n", "  \"displayDescription\": false,\n", "  \"displaySectionTableOfContents\": true,\n", "  \"displayQueryParameters\": false,\n", "  \"sections\": [\n", "    {\n", "      \"name\": \"section 1\",\n", "      \"rows\": [\n", "        {\n", "          \"charts\": [\n", "            {\n", "              \"name\": \"chart 1\",\n", "              \"sources\": [\n", "                {\n", "                  \"name\": \"source 1\",\n", "                  \"query\": \"ts()\",\n", "                  \"scatterPlotSource\": \"Y\",\n", "                  \"querybuilderEnabled\": false,\n", "                  \"sourceDescription\": \"\"\n", "                }\n", "              ],\n", "              \"units\": \"someunit\",\n", "              \"base\": 0,\n", "              \"noDefaultEvents\": false,\n", "              \"interpolatePoints\": false,\n", "              \"includeObsoleteMetrics\": false,\n", "              \"description\": \"This is chart 1, showing something\",\n", "              \"chartSettings\": {\n", "                \"type\": \"markdown-widget\",\n", "                \"max\": 100,\n", "                \"expectedDataSpacing\": 120,\n", "                \"windowing\": \"full\",\n", "                \"windowSize\": 10,\n", "                \"autoColumnTags\": false,\n", "                \"columnTags\": \"deprecated\",\n", "                \"tagMode\": \"all\",\n", "                \"numTags\": 2,\n", "                \"customTags\": [\n", "                  \"tag1\",\n", "                  \"tag2\"\n", "                ],\n", "                \"groupBySource\": true,\n", "                \"y1Max\": 100,\n", "                \"y1Units\": \"units\",\n", "                \"y0ScaleSIBy1024\": true,\n", "                \"y1ScaleSIBy1024\": true,\n", "                \"y0UnitAutoscaling\": true,\n", "                \"y1UnitAutoscaling\": true,\n", "                \"fixedLegendEnabled\": true,\n", "                \"fixedLegendUseRawStats\": true,\n", "                \"fixedLegendPosition\": \"RIGHT\",\n", "                \"fixedLegendDisplayStats\": [\n", "                  \"stat1\",\n", "                  \"stat2\"\n", "                ],\n", "                \"fixedLegendFilterSort\": \"TOP\",\n", "                \"fixedLegendFilterLimit\": 1,\n", "                \"fixedLegendFilterField\": \"CURRENT\",\n", "                \"plainMarkdownContent\": \"markdown content\"\n", "              },\n", "              \"summarization\": \"MEAN\"\n", "            }\n", "          ],\n", "          \"heightFactor\": 50\n", "        }\n", "      ]\n", "    }\n", "  ],\n", "  \"parameterDetails\": {\n", "    \"param\": {\n", "      \"hideFromView\": false,\n", "      \"description\": null,\n", "      \"allowAll\": null,\n", "      \"tagKey\": null,\n", "      \"queryValue\": null,\n", "      \"dynamicFieldType\": null,\n", "      \"reverseDynSort\": null,\n", "      \"parameterType\": \"SIMPLE\",\n", "      \"label\": \"test\",\n", "      \"defaultValue\": \"Label\",\n", "      \"valuesToReadableStrings\": {\n", "        \"Label\": \"test\"\n", "      },\n", "      \"selectedLabel\": \"Label\",\n", "      \"value\": \"test\"\n", "    }\n", "  },\n", "  \"tags\" :{\n", "    \"customerTags\":  [\"terraform\"]\n", "  }\n", "}\n", "\n")),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -43,7 +46,9 @@ import (
 // Dashboard JSON can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/dashboardJson:DashboardJson dashboard_json tftestimport
+//
+//	$ pulumi import wavefront:index/dashboardJson:DashboardJson dashboard_json tftestimport
+//
 // ```
 type DashboardJson struct {
 	pulumi.CustomResourceState
@@ -139,7 +144,7 @@ func (i *DashboardJson) ToDashboardJsonOutputWithContext(ctx context.Context) Da
 // DashboardJsonArrayInput is an input type that accepts DashboardJsonArray and DashboardJsonArrayOutput values.
 // You can construct a concrete instance of `DashboardJsonArrayInput` via:
 //
-//          DashboardJsonArray{ DashboardJsonArgs{...} }
+//	DashboardJsonArray{ DashboardJsonArgs{...} }
 type DashboardJsonArrayInput interface {
 	pulumi.Input
 
@@ -164,7 +169,7 @@ func (i DashboardJsonArray) ToDashboardJsonArrayOutputWithContext(ctx context.Co
 // DashboardJsonMapInput is an input type that accepts DashboardJsonMap and DashboardJsonMapOutput values.
 // You can construct a concrete instance of `DashboardJsonMapInput` via:
 //
-//          DashboardJsonMap{ "key": DashboardJsonArgs{...} }
+//	DashboardJsonMap{ "key": DashboardJsonArgs{...} }
 type DashboardJsonMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/derivedMetric.go
+++ b/sdk/go/wavefront/derivedMetric.go
@@ -20,22 +20,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewDerivedMetric(ctx, "derived", &wavefront.DerivedMetricArgs{
-// 			Minutes: pulumi.Int(5),
-// 			Query:   pulumi.String("aliasMetric(5, \"some.metric\")"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewDerivedMetric(ctx, "derived", &wavefront.DerivedMetricArgs{
+//				Minutes: pulumi.Int(5),
+//				Query:   pulumi.String("aliasMetric(5, \"some.metric\")"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -43,7 +46,9 @@ import (
 // Derived Metrics can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/derivedMetric:DerivedMetric derived_metric 1577102900578
+//
+//	$ pulumi import wavefront:index/derivedMetric:DerivedMetric derived_metric 1577102900578
+//
 // ```
 type DerivedMetric struct {
 	pulumi.CustomResourceState
@@ -177,7 +182,7 @@ func (i *DerivedMetric) ToDerivedMetricOutputWithContext(ctx context.Context) De
 // DerivedMetricArrayInput is an input type that accepts DerivedMetricArray and DerivedMetricArrayOutput values.
 // You can construct a concrete instance of `DerivedMetricArrayInput` via:
 //
-//          DerivedMetricArray{ DerivedMetricArgs{...} }
+//	DerivedMetricArray{ DerivedMetricArgs{...} }
 type DerivedMetricArrayInput interface {
 	pulumi.Input
 
@@ -202,7 +207,7 @@ func (i DerivedMetricArray) ToDerivedMetricArrayOutputWithContext(ctx context.Co
 // DerivedMetricMapInput is an input type that accepts DerivedMetricMap and DerivedMetricMapOutput values.
 // You can construct a concrete instance of `DerivedMetricMapInput` via:
 //
-//          DerivedMetricMap{ "key": DerivedMetricArgs{...} }
+//	DerivedMetricMap{ "key": DerivedMetricArgs{...} }
 type DerivedMetricMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/doc.go
+++ b/sdk/go/wavefront/doc.go
@@ -1,3 +1,2 @@
 // A Pulumi package for creating and managing wavefront cloud resources.
-//
 package wavefront

--- a/sdk/go/wavefront/externalLink.go
+++ b/sdk/go/wavefront/externalLink.go
@@ -19,22 +19,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewExternalLink(ctx, "basic", &wavefront.ExternalLinkArgs{
-// 			Description: pulumi.String("An external link description"),
-// 			Template:    pulumi.String("https://example.com/source={{{source}}}&startTime={{startEpochMillis}}"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewExternalLink(ctx, "basic", &wavefront.ExternalLinkArgs{
+//				Description: pulumi.String("An external link description"),
+//				Template:    pulumi.String("https://example.com/source={{{source}}}&startTime={{startEpochMillis}}"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -42,7 +45,9 @@ import (
 // Maintenance windows can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/externalLink:ExternalLink basic fVj6fz6zYC4aBkID
+//
+//	$ pulumi import wavefront:index/externalLink:ExternalLink basic fVj6fz6zYC4aBkID
+//
 // ```
 type ExternalLink struct {
 	pulumi.CustomResourceState
@@ -211,7 +216,7 @@ func (i *ExternalLink) ToExternalLinkOutputWithContext(ctx context.Context) Exte
 // ExternalLinkArrayInput is an input type that accepts ExternalLinkArray and ExternalLinkArrayOutput values.
 // You can construct a concrete instance of `ExternalLinkArrayInput` via:
 //
-//          ExternalLinkArray{ ExternalLinkArgs{...} }
+//	ExternalLinkArray{ ExternalLinkArgs{...} }
 type ExternalLinkArrayInput interface {
 	pulumi.Input
 
@@ -236,7 +241,7 @@ func (i ExternalLinkArray) ToExternalLinkArrayOutputWithContext(ctx context.Cont
 // ExternalLinkMapInput is an input type that accepts ExternalLinkMap and ExternalLinkMapOutput values.
 // You can construct a concrete instance of `ExternalLinkMapInput` via:
 //
-//          ExternalLinkMap{ "key": ExternalLinkArgs{...} }
+//	ExternalLinkMap{ "key": ExternalLinkArgs{...} }
 type ExternalLinkMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/getDefaultUserGroup.go
+++ b/sdk/go/wavefront/getDefaultUserGroup.go
@@ -15,19 +15,22 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.GetDefaultUserGroup(ctx, nil, nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.GetDefaultUserGroup(ctx, nil, nil)
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 func GetDefaultUserGroup(ctx *pulumi.Context, opts ...pulumi.InvokeOption) (*GetDefaultUserGroupResult, error) {
 	var rv GetDefaultUserGroupResult

--- a/sdk/go/wavefront/ingestionPolicy.go
+++ b/sdk/go/wavefront/ingestionPolicy.go
@@ -19,21 +19,24 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewIngestionPolicy(ctx, "basic", &wavefront.IngestionPolicyArgs{
-// 			Description: pulumi.String("An ingestion policy for testing"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewIngestionPolicy(ctx, "basic", &wavefront.IngestionPolicyArgs{
+//				Description: pulumi.String("An ingestion policy for testing"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -41,7 +44,9 @@ import (
 // ingestion policies can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/ingestionPolicy:IngestionPolicy basic test_ingestion-1611946841064
+//
+//	$ pulumi import wavefront:index/ingestionPolicy:IngestionPolicy basic test_ingestion-1611946841064
+//
 // ```
 type IngestionPolicy struct {
 	pulumi.CustomResourceState
@@ -142,7 +147,7 @@ func (i *IngestionPolicy) ToIngestionPolicyOutputWithContext(ctx context.Context
 // IngestionPolicyArrayInput is an input type that accepts IngestionPolicyArray and IngestionPolicyArrayOutput values.
 // You can construct a concrete instance of `IngestionPolicyArrayInput` via:
 //
-//          IngestionPolicyArray{ IngestionPolicyArgs{...} }
+//	IngestionPolicyArray{ IngestionPolicyArgs{...} }
 type IngestionPolicyArrayInput interface {
 	pulumi.Input
 
@@ -167,7 +172,7 @@ func (i IngestionPolicyArray) ToIngestionPolicyArrayOutputWithContext(ctx contex
 // IngestionPolicyMapInput is an input type that accepts IngestionPolicyMap and IngestionPolicyMapOutput values.
 // You can construct a concrete instance of `IngestionPolicyMapInput` via:
 //
-//          IngestionPolicyMap{ "key": IngestionPolicyArgs{...} }
+//	IngestionPolicyMap{ "key": IngestionPolicyArgs{...} }
 type IngestionPolicyMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/maintenanceWindow.go
+++ b/sdk/go/wavefront/maintenanceWindow.go
@@ -19,28 +19,31 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewMaintenanceWindow(ctx, "basic", &wavefront.MaintenanceWindowArgs{
-// 			EndTimeInSeconds: pulumi.Int(1601123456),
-// 			Reason:           pulumi.String("Routine maintenance for 2020"),
-// 			RelevantHostNames: pulumi.StringArray{
-// 				pulumi.String("my_hostname"),
-// 				pulumi.String("my_other_hostname"),
-// 			},
-// 			StartTimeInSeconds: pulumi.Int(1600123456),
-// 			Title:              pulumi.String("Routine maintenance"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewMaintenanceWindow(ctx, "basic", &wavefront.MaintenanceWindowArgs{
+//				EndTimeInSeconds: pulumi.Int(1601123456),
+//				Reason:           pulumi.String("Routine maintenance for 2020"),
+//				RelevantHostNames: pulumi.StringArray{
+//					pulumi.String("my_hostname"),
+//					pulumi.String("my_other_hostname"),
+//				},
+//				StartTimeInSeconds: pulumi.Int(1600123456),
+//				Title:              pulumi.String("Routine maintenance"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -48,7 +51,9 @@ import (
 // Maintenance windows can be imported using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/maintenanceWindow:MaintenanceWindow basic 1600383357095
+//
+//	$ pulumi import wavefront:index/maintenanceWindow:MaintenanceWindow basic 1600383357095
+//
 // ```
 type MaintenanceWindow struct {
 	pulumi.CustomResourceState
@@ -283,7 +288,7 @@ func (i *MaintenanceWindow) ToMaintenanceWindowOutputWithContext(ctx context.Con
 // MaintenanceWindowArrayInput is an input type that accepts MaintenanceWindowArray and MaintenanceWindowArrayOutput values.
 // You can construct a concrete instance of `MaintenanceWindowArrayInput` via:
 //
-//          MaintenanceWindowArray{ MaintenanceWindowArgs{...} }
+//	MaintenanceWindowArray{ MaintenanceWindowArgs{...} }
 type MaintenanceWindowArrayInput interface {
 	pulumi.Input
 
@@ -308,7 +313,7 @@ func (i MaintenanceWindowArray) ToMaintenanceWindowArrayOutputWithContext(ctx co
 // MaintenanceWindowMapInput is an input type that accepts MaintenanceWindowMap and MaintenanceWindowMapOutput values.
 // You can construct a concrete instance of `MaintenanceWindowMapInput` via:
 //
-//          MaintenanceWindowMap{ "key": MaintenanceWindowArgs{...} }
+//	MaintenanceWindowMap{ "key": MaintenanceWindowArgs{...} }
 type MaintenanceWindowMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/pulumiTypes.go
+++ b/sdk/go/wavefront/pulumiTypes.go
@@ -20,7 +20,7 @@ type AlertTargetRoute struct {
 // AlertTargetRouteInput is an input type that accepts AlertTargetRouteArgs and AlertTargetRouteOutput values.
 // You can construct a concrete instance of `AlertTargetRouteInput` via:
 //
-//          AlertTargetRouteArgs{...}
+//	AlertTargetRouteArgs{...}
 type AlertTargetRouteInput interface {
 	pulumi.Input
 
@@ -50,7 +50,7 @@ func (i AlertTargetRouteArgs) ToAlertTargetRouteOutputWithContext(ctx context.Co
 // AlertTargetRouteArrayInput is an input type that accepts AlertTargetRouteArray and AlertTargetRouteArrayOutput values.
 // You can construct a concrete instance of `AlertTargetRouteArrayInput` via:
 //
-//          AlertTargetRouteArray{ AlertTargetRouteArgs{...} }
+//	AlertTargetRouteArray{ AlertTargetRouteArgs{...} }
 type AlertTargetRouteArrayInput interface {
 	pulumi.Input
 
@@ -129,7 +129,7 @@ type CloudIntegrationNewRelicMetricFilter struct {
 // CloudIntegrationNewRelicMetricFilterInput is an input type that accepts CloudIntegrationNewRelicMetricFilterArgs and CloudIntegrationNewRelicMetricFilterOutput values.
 // You can construct a concrete instance of `CloudIntegrationNewRelicMetricFilterInput` via:
 //
-//          CloudIntegrationNewRelicMetricFilterArgs{...}
+//	CloudIntegrationNewRelicMetricFilterArgs{...}
 type CloudIntegrationNewRelicMetricFilterInput interface {
 	pulumi.Input
 
@@ -159,7 +159,7 @@ func (i CloudIntegrationNewRelicMetricFilterArgs) ToCloudIntegrationNewRelicMetr
 // CloudIntegrationNewRelicMetricFilterArrayInput is an input type that accepts CloudIntegrationNewRelicMetricFilterArray and CloudIntegrationNewRelicMetricFilterArrayOutput values.
 // You can construct a concrete instance of `CloudIntegrationNewRelicMetricFilterArrayInput` via:
 //
-//          CloudIntegrationNewRelicMetricFilterArray{ CloudIntegrationNewRelicMetricFilterArgs{...} }
+//	CloudIntegrationNewRelicMetricFilterArray{ CloudIntegrationNewRelicMetricFilterArgs{...} }
 type CloudIntegrationNewRelicMetricFilterArrayInput interface {
 	pulumi.Input
 
@@ -251,7 +251,7 @@ type DashboardParameterDetail struct {
 // DashboardParameterDetailInput is an input type that accepts DashboardParameterDetailArgs and DashboardParameterDetailOutput values.
 // You can construct a concrete instance of `DashboardParameterDetailInput` via:
 //
-//          DashboardParameterDetailArgs{...}
+//	DashboardParameterDetailArgs{...}
 type DashboardParameterDetailInput interface {
 	pulumi.Input
 
@@ -297,7 +297,7 @@ func (i DashboardParameterDetailArgs) ToDashboardParameterDetailOutputWithContex
 // DashboardParameterDetailArrayInput is an input type that accepts DashboardParameterDetailArray and DashboardParameterDetailArrayOutput values.
 // You can construct a concrete instance of `DashboardParameterDetailArrayInput` via:
 //
-//          DashboardParameterDetailArray{ DashboardParameterDetailArgs{...} }
+//	DashboardParameterDetailArray{ DashboardParameterDetailArgs{...} }
 type DashboardParameterDetailArrayInput interface {
 	pulumi.Input
 
@@ -410,7 +410,7 @@ type DashboardSection struct {
 // DashboardSectionInput is an input type that accepts DashboardSectionArgs and DashboardSectionOutput values.
 // You can construct a concrete instance of `DashboardSectionInput` via:
 //
-//          DashboardSectionArgs{...}
+//	DashboardSectionArgs{...}
 type DashboardSectionInput interface {
 	pulumi.Input
 
@@ -440,7 +440,7 @@ func (i DashboardSectionArgs) ToDashboardSectionOutputWithContext(ctx context.Co
 // DashboardSectionArrayInput is an input type that accepts DashboardSectionArray and DashboardSectionArrayOutput values.
 // You can construct a concrete instance of `DashboardSectionArrayInput` via:
 //
-//          DashboardSectionArray{ DashboardSectionArgs{...} }
+//	DashboardSectionArray{ DashboardSectionArgs{...} }
 type DashboardSectionArrayInput interface {
 	pulumi.Input
 
@@ -514,7 +514,7 @@ type DashboardSectionRow struct {
 // DashboardSectionRowInput is an input type that accepts DashboardSectionRowArgs and DashboardSectionRowOutput values.
 // You can construct a concrete instance of `DashboardSectionRowInput` via:
 //
-//          DashboardSectionRowArgs{...}
+//	DashboardSectionRowArgs{...}
 type DashboardSectionRowInput interface {
 	pulumi.Input
 
@@ -542,7 +542,7 @@ func (i DashboardSectionRowArgs) ToDashboardSectionRowOutputWithContext(ctx cont
 // DashboardSectionRowArrayInput is an input type that accepts DashboardSectionRowArray and DashboardSectionRowArrayOutput values.
 // You can construct a concrete instance of `DashboardSectionRowArrayInput` via:
 //
-//          DashboardSectionRowArray{ DashboardSectionRowArgs{...} }
+//	DashboardSectionRowArray{ DashboardSectionRowArgs{...} }
 type DashboardSectionRowArrayInput interface {
 	pulumi.Input
 
@@ -625,7 +625,7 @@ type DashboardSectionRowChart struct {
 // DashboardSectionRowChartInput is an input type that accepts DashboardSectionRowChartArgs and DashboardSectionRowChartOutput values.
 // You can construct a concrete instance of `DashboardSectionRowChartInput` via:
 //
-//          DashboardSectionRowChartArgs{...}
+//	DashboardSectionRowChartArgs{...}
 type DashboardSectionRowChartInput interface {
 	pulumi.Input
 
@@ -667,7 +667,7 @@ func (i DashboardSectionRowChartArgs) ToDashboardSectionRowChartOutputWithContex
 // DashboardSectionRowChartArrayInput is an input type that accepts DashboardSectionRowChartArray and DashboardSectionRowChartArrayOutput values.
 // You can construct a concrete instance of `DashboardSectionRowChartArrayInput` via:
 //
-//          DashboardSectionRowChartArray{ DashboardSectionRowChartArgs{...} }
+//	DashboardSectionRowChartArray{ DashboardSectionRowChartArgs{...} }
 type DashboardSectionRowChartArrayInput interface {
 	pulumi.Input
 
@@ -909,7 +909,7 @@ type DashboardSectionRowChartChartSetting struct {
 // DashboardSectionRowChartChartSettingInput is an input type that accepts DashboardSectionRowChartChartSettingArgs and DashboardSectionRowChartChartSettingOutput values.
 // You can construct a concrete instance of `DashboardSectionRowChartChartSettingInput` via:
 //
-//          DashboardSectionRowChartChartSettingArgs{...}
+//	DashboardSectionRowChartChartSettingArgs{...}
 type DashboardSectionRowChartChartSettingInput interface {
 	pulumi.Input
 
@@ -1415,7 +1415,7 @@ type DashboardSectionRowChartSource struct {
 // DashboardSectionRowChartSourceInput is an input type that accepts DashboardSectionRowChartSourceArgs and DashboardSectionRowChartSourceOutput values.
 // You can construct a concrete instance of `DashboardSectionRowChartSourceInput` via:
 //
-//          DashboardSectionRowChartSourceArgs{...}
+//	DashboardSectionRowChartSourceArgs{...}
 type DashboardSectionRowChartSourceInput interface {
 	pulumi.Input
 
@@ -1453,7 +1453,7 @@ func (i DashboardSectionRowChartSourceArgs) ToDashboardSectionRowChartSourceOutp
 // DashboardSectionRowChartSourceArrayInput is an input type that accepts DashboardSectionRowChartSourceArray and DashboardSectionRowChartSourceArrayOutput values.
 // You can construct a concrete instance of `DashboardSectionRowChartSourceArrayInput` via:
 //
-//          DashboardSectionRowChartSourceArray{ DashboardSectionRowChartSourceArgs{...} }
+//	DashboardSectionRowChartSourceArray{ DashboardSectionRowChartSourceArgs{...} }
 type DashboardSectionRowChartSourceArrayInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/role.go
+++ b/sdk/go/wavefront/role.go
@@ -18,19 +18,22 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewRole(ctx, "role", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewRole(ctx, "role", nil)
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -38,7 +41,9 @@ import (
 // Roles can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/role:Role some_role a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/role:Role some_role a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type Role struct {
 	pulumi.CustomResourceState
@@ -166,7 +171,7 @@ func (i *Role) ToRoleOutputWithContext(ctx context.Context) RoleOutput {
 // RoleArrayInput is an input type that accepts RoleArray and RoleArrayOutput values.
 // You can construct a concrete instance of `RoleArrayInput` via:
 //
-//          RoleArray{ RoleArgs{...} }
+//	RoleArray{ RoleArgs{...} }
 type RoleArrayInput interface {
 	pulumi.Input
 
@@ -191,7 +196,7 @@ func (i RoleArray) ToRoleArrayOutputWithContext(ctx context.Context) RoleArrayOu
 // RoleMapInput is an input type that accepts RoleMap and RoleMapOutput values.
 // You can construct a concrete instance of `RoleMapInput` via:
 //
-//          RoleMap{ "key": RoleArgs{...} }
+//	RoleMap{ "key": RoleArgs{...} }
 type RoleMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/serviceAccount.go
+++ b/sdk/go/wavefront/serviceAccount.go
@@ -19,22 +19,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewServiceAccount(ctx, "basic", &wavefront.ServiceAccountArgs{
-// 			Active:     pulumi.Bool(true),
-// 			Identifier: pulumi.String("sa::tftesting"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewServiceAccount(ctx, "basic", &wavefront.ServiceAccountArgs{
+//				Active:     pulumi.Bool(true),
+//				Identifier: pulumi.String("sa::tftesting"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -42,7 +45,9 @@ import (
 // Service accounts can be imported by using `identifier`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/serviceAccount:ServiceAccount basic sa::tftesting
+//
+//	$ pulumi import wavefront:index/serviceAccount:ServiceAccount basic sa::tftesting
+//
 // ```
 type ServiceAccount struct {
 	pulumi.CustomResourceState
@@ -193,7 +198,7 @@ func (i *ServiceAccount) ToServiceAccountOutputWithContext(ctx context.Context) 
 // ServiceAccountArrayInput is an input type that accepts ServiceAccountArray and ServiceAccountArrayOutput values.
 // You can construct a concrete instance of `ServiceAccountArrayInput` via:
 //
-//          ServiceAccountArray{ ServiceAccountArgs{...} }
+//	ServiceAccountArray{ ServiceAccountArgs{...} }
 type ServiceAccountArrayInput interface {
 	pulumi.Input
 
@@ -218,7 +223,7 @@ func (i ServiceAccountArray) ToServiceAccountArrayOutputWithContext(ctx context.
 // ServiceAccountMapInput is an input type that accepts ServiceAccountMap and ServiceAccountMapOutput values.
 // You can construct a concrete instance of `ServiceAccountMapInput` via:
 //
-//          ServiceAccountMap{ "key": ServiceAccountArgs{...} }
+//	ServiceAccountMap{ "key": ServiceAccountArgs{...} }
 type ServiceAccountMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/user.go
+++ b/sdk/go/wavefront/user.go
@@ -19,21 +19,24 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewUser(ctx, "basic", &wavefront.UserArgs{
-// 			Email: pulumi.String("test+tftesting@example.com"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewUser(ctx, "basic", &wavefront.UserArgs{
+//				Email: pulumi.String("test+tftesting@example.com"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -41,7 +44,9 @@ import (
 // Users can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/user:User some_user test@example.com
+//
+//	$ pulumi import wavefront:index/user:User some_user test@example.com
+//
 // ```
 type User struct {
 	pulumi.CustomResourceState
@@ -167,7 +172,7 @@ func (i *User) ToUserOutputWithContext(ctx context.Context) UserOutput {
 // UserArrayInput is an input type that accepts UserArray and UserArrayOutput values.
 // You can construct a concrete instance of `UserArrayInput` via:
 //
-//          UserArray{ UserArgs{...} }
+//	UserArray{ UserArgs{...} }
 type UserArrayInput interface {
 	pulumi.Input
 
@@ -192,7 +197,7 @@ func (i UserArray) ToUserArrayOutputWithContext(ctx context.Context) UserArrayOu
 // UserMapInput is an input type that accepts UserMap and UserMapOutput values.
 // You can construct a concrete instance of `UserMapInput` via:
 //
-//          UserMap{ "key": UserArgs{...} }
+//	UserMap{ "key": UserArgs{...} }
 type UserMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/wavefront/userGroup.go
+++ b/sdk/go/wavefront/userGroup.go
@@ -19,21 +19,24 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-wavefront/sdk/go/wavefront"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := wavefront.NewUserGroup(ctx, "basic", &wavefront.UserGroupArgs{
-// 			Description: pulumi.String("Basic User Group for Unit Tests"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := wavefront.NewUserGroup(ctx, "basic", &wavefront.UserGroupArgs{
+//				Description: pulumi.String("Basic User Group for Unit Tests"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -41,7 +44,9 @@ import (
 // User Groups can be imported by using the `id`, e.g.
 //
 // ```sh
-//  $ pulumi import wavefront:index/userGroup:UserGroup some_group a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
+//	$ pulumi import wavefront:index/userGroup:UserGroup some_group a411c16b-3cf7-4f03-bf11-8ca05aab898d
+//
 // ```
 type UserGroup struct {
 	pulumi.CustomResourceState
@@ -142,7 +147,7 @@ func (i *UserGroup) ToUserGroupOutputWithContext(ctx context.Context) UserGroupO
 // UserGroupArrayInput is an input type that accepts UserGroupArray and UserGroupArrayOutput values.
 // You can construct a concrete instance of `UserGroupArrayInput` via:
 //
-//          UserGroupArray{ UserGroupArgs{...} }
+//	UserGroupArray{ UserGroupArgs{...} }
 type UserGroupArrayInput interface {
 	pulumi.Input
 
@@ -167,7 +172,7 @@ func (i UserGroupArray) ToUserGroupArrayOutputWithContext(ctx context.Context) U
 // UserGroupMapInput is an input type that accepts UserGroupMap and UserGroupMapOutput values.
 // You can construct a concrete instance of `UserGroupMapInput` via:
 //
-//          UserGroupMap{ "key": UserGroupArgs{...} }
+//	UserGroupMap{ "key": UserGroupArgs{...} }
 type UserGroupMapInput interface {
 	pulumi.Input
 

--- a/sdk/nodejs/go.mod
+++ b/sdk/nodejs/go.mod
@@ -1,0 +1,3 @@
+module fake_nodejs_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/python/go.mod
+++ b/sdk/python/go.mod
@@ -1,0 +1,3 @@
+module fake_python_module // Exclude this directory from Go tools
+
+go 1.16


### PR DESCRIPTION
Since "js" is listed as an OS in [goos.GOOS](https://pkg.go.dev/internal/goos#GOOS), "_js" was interpreted as an OS constraint and the test never ran.

> If a file's name, after stripping the extension and a possible _test suffix, matches any of the following patterns:
>	*_GOOS
>	*_GOARCH
>	*_GOOS_GOARCH
>(example: source_windows_amd64.go) where GOOS and GOARCH represent any known operating system and architecture >values respectively, then the file is considered to have an implicit build constraint requiring those terms

Also update the build constraints to the Go 1.17+ syntax (via gofmt).